### PR TITLE
extend regexp match patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,25 @@
 var babel = require('babel-core'),
     djangoGettextTransformPlugin = require('./babel-django-gettext-transform-plugin');
 
+var matchPatterns = [
+        '\{\{(.+?)\}\}',
+        '\:[a-zA-Z]+=\".*(_\(.+?\))\"'
+    ],
+    regExp = new RegExp(matchPatterns.join('|'), 'gi');
+
 module.exports = function (source) {
-    source = source.replace(/\{\{(.+?)\}\}/gi, function (full, matched) {
-        var result = babel.transform(matched.trim(), {
+    source = source.replace(regExp, function (full, ...matched) {
+        var matchedExpression = matched.slice(0, matchPatterns.length).filter(Boolean)[0];
+        var result = babel.transform(matchedExpression.trim(), {
             plugins: [djangoGettextTransformPlugin]
         });
+        var newExpression = result.code.replace(/;$/, '');
+        
+        if (new RegExp(matchPatterns[0]).test(full)) {
+            newExpression = ' ' + newExpression + ' ';
+        }
 
-        return '{{ ' + result.code.replace(/;$/, '') + ' }}';
+        return full.replace(matchedExpression, newExpression);
     });
     return source;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "django-gettext-vue-loader",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "django-gettext-vue-loader",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Loader for vue.js templates that allows to use django gettext template syntax",
   "main": "index.js",
   "repository": "PavloKovalov/django-gettext-vue-loader",

--- a/tests.js
+++ b/tests.js
@@ -11,7 +11,10 @@ var transformTests = {
   '{{ username | capitalize }}': '{{ username | capitalize }}',
   '{{ "substitute %s" % "it" }}': '{{ interpolate("substitute %s", ["it"]) }}',
   '{{ \'<p>%s</p>\' % _(\'Hello\') }}': '{{ interpolate(\'<p>%s</p>\', gettext(\'Hello\')) }}',
-  '{{ "User: %(first)s %(last)s" % {"first": _("Kylo"), "last": _("Ren") } }}': '{{ interpolate("User: %(first)s %(last)s", { "first": gettext("Kylo"), "last": gettext("Ren") }, true) }}'
+  '{{ "User: %(first)s %(last)s" % {"first": _("Kylo"), "last": _("Ren") } }}': '{{ interpolate("User: %(first)s %(last)s", { "first": gettext("Kylo"), "last": gettext("Ren") }, true) }}',
+  ':placeholder="_(\'lorem ipsum dolor\')"': ':placeholder="gettext(\'lorem ipsum dolor\')"',
+  ':placeholder="someProp || _(\'lorem ipsum dolor\')"': ':placeholder="someProp || gettext(\'lorem ipsum dolor\')"',
+  '<fieldset class="some-fieldset" :class="{active: true}">': '<fieldset class="some-fieldset" :class="{active: true}">'
 };
 
 tape('loader should be a function', (t) => {


### PR DESCRIPTION
Implement possibility to parse templates with next syntax without curly braces:
`<input type="text" :placeholder="_('Localized placeholder')">`

And transform it's to this:
`<input type="text" :placeholder="gettext('Localized placeholder')">`