### PR TITLE
fix regexp behaviour for html tag attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var babel = require('babel-core'),
 
 var matchPatterns = [
         '\{\{(.+?)\}\}',
-        '\:[a-zA-Z]+=\".*(_\(.+?\))\"'
+        ':[a-zA-Z]+="[^_\n]*(_[\(]\'.+\'[\)])"'
     ],
     regExp = new RegExp(matchPatterns.join('|'), 'gi');
 

--- a/tests.js
+++ b/tests.js
@@ -14,7 +14,8 @@ var transformTests = {
   '{{ "User: %(first)s %(last)s" % {"first": _("Kylo"), "last": _("Ren") } }}': '{{ interpolate("User: %(first)s %(last)s", { "first": gettext("Kylo"), "last": gettext("Ren") }, true) }}',
   ':placeholder="_(\'lorem ipsum dolor\')"': ':placeholder="gettext(\'lorem ipsum dolor\')"',
   ':placeholder="someProp || _(\'lorem ipsum dolor\')"': ':placeholder="someProp || gettext(\'lorem ipsum dolor\')"',
-  '<fieldset class="some-fieldset" :class="{active: true}">': '<fieldset class="some-fieldset" :class="{active: true}">'
+  '<fieldset class="some-fieldset" :class="{active: true}">': '<fieldset class="some-fieldset" :class="{active: true}">',
+  '<div> <input :key="`touch__${option.value}`"> </div>': '<div> <input :key="`touch__${option.value}`"> </div>'
 };
 
 tape('loader should be a function', (t) => {


### PR DESCRIPTION
Fix regexp invalid behaviour with template literals like this one in **key**  attribute:
```vue
<ul>
  <li v-for="item in items" :key="`item__${item.key}`">{{ item.name }}</li>
</ul>
```